### PR TITLE
Add club management and club-specific candidate fields

### DIFF
--- a/E-election/assets/js/admin_accueil.js
+++ b/E-election/assets/js/admin_accueil.js
@@ -61,6 +61,12 @@ document.addEventListener('DOMContentLoaded', () => {
               <div class="admin-link">
                 <a href="#" id="deletePoste" style="color:#fff;text-decoration:underline;">supprimer un poste</a>
               </div>
+              <div class="admin-link" style="margin:18px 0;">
+                <a href="#" id="addClub" style="color:#fff;text-decoration:underline;">Ajouter un club</a>
+              </div>
+              <div class="admin-link">
+                <a href="#" id="deleteClub" style="color:#fff;text-decoration:underline;">supprimer un club</a>
+              </div>
               <div class="admin-link">
                 <a href="pages/vote.html" id="etatVotes" style="color:#fff;text-decoration:underline;">Etat des votes</a>
               </div>
@@ -85,7 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
           document.getElementById('validateBtn').onclick = () => {
             alert('Modifications validées !');
           };
-          // Ajouter un poste PAR TYPE
+          // Ajouter un poste PAR TYPE OU CLUB
           const addPoste = document.getElementById('addPoste');
           if (addPoste) {
             addPoste.onclick = (e) => {
@@ -95,38 +101,115 @@ document.addEventListener('DOMContentLoaded', () => {
                 alert('Type d\'élection invalide.');
                 return;
               }
+              let club = '';
+              if (type === 'club') {
+                const clubs = JSON.parse(localStorage.getItem('clubs')) || [];
+                if (clubs.length === 0) { alert('Aucun club disponible.'); return; }
+                const idx = prompt('Choisissez le club :\n' + clubs.map((c,i)=>`${i+1}. ${c}`).join('\n'));
+                const i = parseInt(idx,10);
+                if (!i || i < 1 || i > clubs.length) return;
+                club = clubs[i-1];
+              }
               const nom = prompt('Nom du nouveau poste :');
               if (nom) {
-                let postesByType = JSON.parse(localStorage.getItem('postesByType')) || {};
-                postesByType[type] = postesByType[type] || [];
-                if (!postesByType[type].includes(nom)) {
-                  postesByType[type].push(nom);
-                  localStorage.setItem('postesByType', JSON.stringify(postesByType));
-                  alert('Poste ajouté pour ' + type + ' !');
+                if (type === 'club') {
+                  let postesByClub = JSON.parse(localStorage.getItem('postesByClub')) || {};
+                  postesByClub[club] = postesByClub[club] || [];
+                  if (!postesByClub[club].includes(nom)) {
+                    postesByClub[club].push(nom);
+                    localStorage.setItem('postesByClub', JSON.stringify(postesByClub));
+                    alert('Poste ajouté pour ' + club + ' !');
+                  } else {
+                    alert('Ce poste existe déjà pour ce club.');
+                  }
                 } else {
-                  alert('Ce poste existe déjà pour ce type.');
+                  let postesByType = JSON.parse(localStorage.getItem('postesByType')) || {};
+                  postesByType[type] = postesByType[type] || [];
+                  if (!postesByType[type].includes(nom)) {
+                    postesByType[type].push(nom);
+                    localStorage.setItem('postesByType', JSON.stringify(postesByType));
+                    alert('Poste ajouté pour ' + type + ' !');
+                  } else {
+                    alert('Ce poste existe déjà pour ce type.');
+                  }
                 }
               }
             };
           }
-          // Supprimer un poste PAR TYPE
+          // Supprimer un poste PAR TYPE OU CLUB
           const deletePoste = document.getElementById('deletePoste');
           if (deletePoste) {
             deletePoste.onclick = (e) => {
               e.preventDefault();
               const type = prompt('Type d\'élection (club, aes, classe) :').toLowerCase();
-              let postesByType = JSON.parse(localStorage.getItem('postesByType')) || {};
-              if (!postesByType[type] || postesByType[type].length === 0) {
-                alert('Aucun poste à supprimer pour ce type.');
-                return;
+              if (!['club', 'aes', 'classe'].includes(type)) return;
+              if (type === 'club') {
+                const clubs = JSON.parse(localStorage.getItem('clubs')) || [];
+                if (clubs.length === 0) { alert('Aucun club disponible.'); return; }
+                const idx = prompt('Choisissez le club :\n' + clubs.map((c,i)=>`${i+1}. ${c}`).join('\n'));
+                const i = parseInt(idx,10);
+                if (!i || i < 1 || i > clubs.length) return;
+                const club = clubs[i-1];
+                let postesByClub = JSON.parse(localStorage.getItem('postesByClub')) || {};
+                const arr = postesByClub[club] || [];
+                if (arr.length === 0) { alert('Aucun poste à supprimer pour ce club.'); return; }
+                const posIdx = prompt('Choisissez le poste :\n' + arr.map((p,j)=>`${j+1}. ${p}`).join('\n'));
+                const j = parseInt(posIdx,10);
+                if (j >=1 && j <= arr.length) {
+                  arr.splice(j-1,1);
+                  postesByClub[club] = arr;
+                  localStorage.setItem('postesByClub', JSON.stringify(postesByClub));
+                  alert('Poste supprimé pour ' + club + ' !');
+                }
+              } else {
+                let postesByType = JSON.parse(localStorage.getItem('postesByType')) || {};
+                const arr = postesByType[type] || [];
+                if (arr.length === 0) { alert('Aucun poste à supprimer pour ce type.'); return; }
+                const posIdx = prompt('Choisissez le poste :\n' + arr.map((p,j)=>`${j+1}. ${p}`).join('\n'));
+                const j = parseInt(posIdx,10);
+                if (j >=1 && j <= arr.length) {
+                  arr.splice(j-1,1);
+                  postesByType[type] = arr;
+                  localStorage.setItem('postesByType', JSON.stringify(postesByType));
+                  alert('Poste supprimé pour ' + type + ' !');
+                }
               }
-              const nom = prompt('Nom du poste à supprimer :\n' + postesByType[type].join(', '));
-              if (nom && postesByType[type].includes(nom)) {
-                postesByType[type] = postesByType[type].filter(p => p !== nom);
-                localStorage.setItem('postesByType', JSON.stringify(postesByType));
-                alert('Poste supprimé pour ' + type + ' !');
-              } else if (nom) {
-                alert('Ce poste n\'existe pas pour ce type.');
+            };
+          }
+          // Ajouter un club
+          const addClub = document.getElementById('addClub');
+          if (addClub) {
+            addClub.onclick = (e) => {
+              e.preventDefault();
+              const nom = prompt('Nom du nouveau club :');
+              if (nom) {
+                let clubs = JSON.parse(localStorage.getItem('clubs')) || [];
+                if (!clubs.includes(nom)) {
+                  clubs.push(nom);
+                  localStorage.setItem('clubs', JSON.stringify(clubs));
+                  alert('Club ajouté !');
+                } else {
+                  alert('Ce club existe déjà.');
+                }
+              }
+            };
+          }
+          // Supprimer un club
+          const deleteClub = document.getElementById('deleteClub');
+          if (deleteClub) {
+            deleteClub.onclick = (e) => {
+              e.preventDefault();
+              let clubs = JSON.parse(localStorage.getItem('clubs')) || [];
+              if (clubs.length === 0) { alert('Aucun club à supprimer.'); return; }
+              const idx = prompt('Quel club supprimer ?\n' + clubs.map((c,i)=>`${i+1}. ${c}`).join('\n'));
+              const i = parseInt(idx,10);
+              if (i >=1 && i <= clubs.length) {
+                const club = clubs.splice(i-1,1)[0];
+                localStorage.setItem('clubs', JSON.stringify(clubs));
+                let postesByClub = JSON.parse(localStorage.getItem('postesByClub')) || {};
+                delete postesByClub[club];
+                localStorage.setItem('postesByClub', JSON.stringify(postesByClub));
+                alert('Club supprimé !');
               }
             };
           }

--- a/E-election/assets/js/candidat.js
+++ b/E-election/assets/js/candidat.js
@@ -32,18 +32,79 @@ function chargerPostes(type) {
   }
 }
 
+function chargerClubs() {
+  const select = document.getElementById('clubSelect');
+  if (!select) return;
+  select.innerHTML = '<option value="">-- Sélectionnez un club --</option>';
+  const clubs = JSON.parse(localStorage.getItem('clubs')) || [];
+  clubs.forEach(club => {
+    const opt = document.createElement('option');
+    opt.value = club;
+    opt.textContent = club;
+    select.appendChild(opt);
+  });
+}
+
+function chargerPostesClub(club) {
+  const select = document.getElementById('poste');
+  if (!select) return;
+  select.innerHTML = '<option value="">-- Sélectionnez un poste --</option>';
+  const postesByClub = JSON.parse(localStorage.getItem('postesByClub')) || {};
+  const postes = postesByClub[club] || [];
+  postes.forEach(poste => {
+    const opt = document.createElement('option');
+    opt.value = poste;
+    opt.textContent = poste;
+    select.appendChild(opt);
+  });
+
+  const validerBtn = document.getElementById('validerCandidatureBtn');
+  if (postes.length === 0) {
+    select.disabled = true;
+    if (validerBtn) validerBtn.disabled = true;
+    if (!document.getElementById('no-poste-msg')) {
+      const msg = document.createElement('div');
+      msg.id = 'no-poste-msg';
+      msg.style.color = 'red';
+      msg.style.marginTop = '10px';
+      msg.textContent = "Aucun poste n'est disponible pour ce club.";
+      select.parentNode.appendChild(msg);
+    }
+  } else {
+    select.disabled = false;
+    if (validerBtn) validerBtn.disabled = false;
+    const msg = document.getElementById('no-poste-msg');
+    if (msg) msg.remove();
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const electionButtons = document.querySelectorAll('.election-btn');
   const form = document.getElementById('newCandidature');
-  
+  const clubGroup = document.getElementById('clubGroup');
+  const clubSelect = document.getElementById('clubSelect');
+
   electionButtons.forEach(btn => {
     btn.addEventListener('click', (e) => {
       const type = e.target.textContent.trim().toLowerCase();
       document.getElementById('electionType').value = e.target.textContent;
       form.style.display = 'block';
-      chargerPostes(type);
+      if (type === 'club') {
+        if (clubGroup) clubGroup.style.display = 'block';
+        chargerClubs();
+        chargerPostesClub(clubSelect.value);
+      } else {
+        if (clubGroup) clubGroup.style.display = 'none';
+        chargerPostes(type);
+      }
     });
   });
+
+  if (clubSelect) {
+    clubSelect.addEventListener('change', (e) => {
+      chargerPostesClub(e.target.value);
+    });
+  }
 
   document.getElementById('validerCandidatureBtn').addEventListener('click', () => {
     const candidature = {
@@ -52,6 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
       nom: document.getElementById('nom').value,
       prenom: document.getElementById('prenom').value,
       classe: document.getElementById('classe').value,
+      club: document.getElementById('clubSelect').value,
       poste: document.getElementById('poste').value,
       programme: document.getElementById('programme').value,
       photo: document.getElementById('photo').files[0] ? 

--- a/E-election/assets/js/mes-candidatures.js
+++ b/E-election/assets/js/mes-candidatures.js
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     card.innerHTML = `
       ${c.photo ? `<img src="${c.photo}" class="candidature-photo">` : ''}
       <div class="candidature-title">${c.prenom} ${c.nom}</div>
-      <div class="candidature-type">${c.type} - ${c.poste}</div>
+      <div class="candidature-type">${c.type}${c.club ? ' - ' + c.club : ''} - ${c.poste}</div>
       <div class="candidature-details">${c.classe} • ${c.date}</div>
       <div class="candidature-programme">${c.programme}</div>
     `;

--- a/E-election/pages/candidat.html
+++ b/E-election/pages/candidat.html
@@ -50,13 +50,18 @@
             <option value="AS3">AS3</option>
           </select>
         </div>
-        
+
+        <div class="form-group" id="clubGroup" style="display:none;">
+          <label for="clubSelect">Club:</label>
+          <select id="clubSelect">
+            <option value="">-- Sélectionnez un club --</option>
+          </select>
+        </div>
+
         <div class="form-group">
           <label for="poste">Poste:</label>
           <select id="poste" required>
             <option value="">-- Sélectionnez un poste --</option>
-            <option value="Présidence">Présidence</option>
-            <option value="Trésorerie">Trésorerie</option>
           </select>
         </div>
         


### PR DESCRIPTION
## Summary
- ask users to choose a club when creating a club candidature
- load posts for a club based on selected club
- display club name in the list of candidatures
- allow administrators to manage clubs and club-specific posts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684221cbc080832596b923888d0df775