### PR TITLE
Improve mobile menu responsiveness

### DIFF
--- a/E-election/accueil.html
+++ b/E-election/accueil.html
@@ -27,6 +27,13 @@
         </div>
       </div>
 
+      <!-- Menu Toggle for Mobile -->
+      <button class="menu-toggle" aria-label="Ouvrir le menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+
       <!-- Navigation -->
       <nav class="main-nav">
         <ul class="nav-menu">

--- a/E-election/assets/css/header.css
+++ b/E-election/assets/css/header.css
@@ -51,6 +51,36 @@ header {
   flex-grow: 1;
 }
 
+/* Menu Toggle */
+.menu-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 28px;
+  height: 21px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-left: auto;
+}
+.menu-toggle span {
+  display: block;
+  width: 100%;
+  height: 3px;
+  background: var(--primary);
+  border-radius: 2px;
+  transition: transform var(--transition), opacity var(--transition);
+}
+.menu-toggle.active span:nth-child(1) {
+  transform: rotate(45deg) translate(5px,5px);
+}
+.menu-toggle.active span:nth-child(2) {
+  opacity: 0;
+}
+.menu-toggle.active span:nth-child(3) {
+  transform: rotate(-45deg) translate(5px,-5px);
+}
+
 .nav-menu {
   display: flex;
   align-items: center;
@@ -139,16 +169,26 @@ header {
     gap: 0.7rem;
   }
 
+  .menu-toggle {
+    display: flex;
+  }
+
   .main-nav {
     width: 100%;
   }
 
   .nav-menu {
+    display: none;
     flex-direction: column;
     background: var(--white);
     padding: 0.5rem;
     border-radius: var(--radius);
     justify-content: flex-start;
+    width: 100%;
+  }
+
+  .nav-menu.active {
+    display: flex;
   }
 
   .dropdown-menu {

--- a/E-election/assets/js/header.js
+++ b/E-election/assets/js/header.js
@@ -6,6 +6,16 @@
     });
   });
 
+  const menuToggle = document.querySelector('.menu-toggle');
+  const navMenu = document.querySelector('.nav-menu');
+
+  if (menuToggle && navMenu) {
+    menuToggle.addEventListener('click', function () {
+      menuToggle.classList.toggle('active');
+      navMenu.classList.toggle('active');
+    });
+  }
+
   // Pour que le clic sur .dropdown-toggle ouvre/ferme le menu
   document.querySelectorAll('.dropdown-toggle').forEach(toggle => {
     toggle.addEventListener('click', function (e) {

--- a/E-election/components/header.html
+++ b/E-election/components/header.html
@@ -15,6 +15,13 @@
       </div>
     </div>
 
+    <!-- Menu Toggle for Mobile -->
+    <button class="menu-toggle" aria-label="Ouvrir le menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+
     <!-- Navigation -->
     <nav class="main-nav">
       <ul class="nav-menu">

--- a/E-election/components/header_home.html
+++ b/E-election/components/header_home.html
@@ -16,6 +16,13 @@
       </div>
     </div>
 
+    <!-- Menu Toggle for Mobile -->
+    <button class="menu-toggle" aria-label="Ouvrir le menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+
     <!-- Navigation principale -->
     <nav class="main-nav">
       <ul class="nav-menu">

--- a/E-election/components/header_root.html
+++ b/E-election/components/header_root.html
@@ -15,6 +15,13 @@
       </div>
     </div>
 
+    <!-- Menu Toggle for Mobile -->
+    <button class="menu-toggle" aria-label="Ouvrir le menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+
     <!-- Navigation -->
     <nav class="main-nav">
       <ul class="nav-menu">


### PR DESCRIPTION
## Summary
- add hamburger menu markup to header components and accueil page
- style and animate the new mobile menu
- implement toggle logic in header.js

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842270557008325b6058d47d1af088d