### PR TITLE
Add start vote modal in admin page

### DIFF
--- a/E-election/assets/css/admin_accueil.css
+++ b/E-election/assets/css/admin_accueil.css
@@ -225,3 +225,56 @@ body {
   transform: translateY(-2px);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.35);
 }
+/* Modal styles specific to admin page */
+.modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  z-index: 1000;
+  justify-content: center;
+  align-items: center;
+}
+.modal-content {
+  background-color: var(--white);
+  padding: 30px;
+  border-radius: 10px;
+  width: 90%;
+  max-width: 500px;
+  color: var(--primary);
+  position: relative;
+}
+.close-btn {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 24px;
+  cursor: pointer;
+  color: var(--primary);
+}
+.form-group {
+  margin-bottom: 15px;
+  text-align: left;
+}
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: bold;
+}
+.form-group input,
+.form-group select {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  box-sizing: border-box;
+}
+.form-actions {
+  margin-top: 20px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}

--- a/E-election/assets/js/admin_accueil.js
+++ b/E-election/assets/js/admin_accueil.js
@@ -91,6 +91,56 @@ document.addEventListener('DOMContentLoaded', () => {
           document.getElementById('validateBtn').onclick = () => {
             alert('Modifications validées !');
           };
+          const startVotesBtn = document.getElementById('startVotesBtn');
+          if (startVotesBtn) {
+            startVotesBtn.onclick = () => {
+              const modal = document.createElement('div');
+              modal.className = 'modal';
+              modal.innerHTML = `
+                <div class="modal-content">
+                  <span class="close-btn">&times;</span>
+                  <h3>Démarrer les votes</h3>
+                  <div class="form-group">
+                    <label for="voteType">Type d'élection</label>
+                    <select id="voteType">
+                      <option value="aes">AES</option>
+                      <option value="club">Club</option>
+                      <option value="classe">Classe</option>
+                    </select>
+                  </div>
+                  <div class="form-group">
+                    <label for="voteStart">Date et heure de début</label>
+                    <input type="datetime-local" id="voteStart">
+                  </div>
+                  <div class="form-group">
+                    <label for="voteEnd">Date et heure de fin</label>
+                    <input type="datetime-local" id="voteEnd">
+                  </div>
+                  <div class="form-actions">
+                    <button id="confirmStartVote" class="admin-btn">valider</button>
+                    <button id="cancelStartVote" class="admin-btn danger">Annuler</button>
+                  </div>
+                </div>`;
+              document.body.appendChild(modal);
+              modal.style.display = 'flex';
+              const closeModal = () => modal.remove();
+              modal.querySelector('.close-btn').onclick = closeModal;
+              modal.querySelector('#cancelStartVote').onclick = closeModal;
+              modal.onclick = e => { if (e.target === modal) closeModal(); };
+              modal.querySelector('#confirmStartVote').onclick = () => {
+                const type = modal.querySelector('#voteType').value;
+                const debut = modal.querySelector('#voteStart').value;
+                const fin = modal.querySelector('#voteEnd').value;
+                if (!type || !debut || !fin) {
+                  alert('Tous les champs sont requis');
+                  return;
+                }
+                localStorage.setItem('voteConfig', JSON.stringify({type, debut, fin}));
+                alert('Votes démarrés !');
+                closeModal();
+              };
+            };
+          }
           // Ajouter un poste PAR TYPE OU CLUB
           const addPoste = document.getElementById('addPoste');
           if (addPoste) {


### PR DESCRIPTION
## Summary
- add modal styles for admin page
- implement vote start modal logic on `Démarrer les votes` button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68422e6337fc83259906f51e144ba8c2