### PR TITLE
Implement admin start options

### DIFF
--- a/E-election/assets/js/admin_accueil.js
+++ b/E-election/assets/js/admin_accueil.js
@@ -91,6 +91,33 @@ document.addEventListener('DOMContentLoaded', () => {
           document.getElementById('validateBtn').onclick = () => {
             alert('Modifications validées !');
           };
+          const startVotesBtn = document.getElementById('startVotesBtn');
+          if (startVotesBtn) {
+            startVotesBtn.onclick = () => {
+              const cat = prompt('Catégorie pour démarrer les votes (aes, club ou classe) ?');
+              const categorie = cat ? cat.toLowerCase() : '';
+              if (!['aes','club','classe'].includes(categorie)) { alert('Catégorie invalide'); return; }
+              const candidats = JSON.parse(localStorage.getItem('candidatures')) || [];
+              const existe = candidats.some(c => (c.type || '').toLowerCase() === categorie);
+              if (!existe) { alert('Pas possible car pas de candidats'); return; }
+              const voteStatut = JSON.parse(localStorage.getItem('voteStatus')) || {};
+              voteStatut[categorie] = true;
+              localStorage.setItem('voteStatus', JSON.stringify(voteStatut));
+              alert('Votes démarrés pour ' + categorie.toUpperCase());
+            };
+          }
+          const stopVotesBtn = document.getElementById('stopVotesBtn');
+          if (stopVotesBtn) {
+            stopVotesBtn.onclick = () => {
+              const cat = prompt('Catégorie à arrêter (aes, club ou classe) ?');
+              const categorie = cat ? cat.toLowerCase() : '';
+              if (!['aes','club','classe'].includes(categorie)) return alert('Catégorie invalide');
+              const voteStatut = JSON.parse(localStorage.getItem('voteStatus')) || {};
+              voteStatut[categorie] = false;
+              localStorage.setItem('voteStatus', JSON.stringify(voteStatut));
+              alert('Votes arrêtés pour ' + categorie.toUpperCase());
+            };
+          }
           // Ajouter un poste PAR TYPE OU CLUB
           const addPoste = document.getElementById('addPoste');
           if (addPoste) {
@@ -231,9 +258,40 @@ document.addEventListener('DOMContentLoaded', () => {
           </div>
         `;
         setTimeout(() => {
-          document.getElementById('startBtn').onclick = () => alert('Candidatures ouvertes !');
-          document.getElementById('closeBtn').onclick = () => alert('Candidatures fermées !');
-          document.getElementById('statsBtn').onclick = () => alert('Statistiques des candidats');
+          const startBtn = document.getElementById('startBtn');
+          if (startBtn) {
+            startBtn.onclick = () => {
+              const cat = prompt("Catégorie (aes, club ou classe) ?");
+              const categorie = cat ? cat.toLowerCase() : "";
+              if (!['aes','club','classe'].includes(categorie)) {
+                alert('Catégorie invalide');
+                return;
+              }
+              const date = prompt('Date de fin (AAAA-MM-JJ) :');
+              const heure = prompt('Heure de fin (HH:MM) :');
+              if (!date || !heure) { alert('Date ou heure invalide'); return; }
+              const fin = new Date(date + 'T' + heure);
+              if (isNaN(fin)) { alert('Date ou heure invalide'); return; }
+              const statut = JSON.parse(localStorage.getItem('candidatureStatus')) || {};
+              statut[categorie] = { ouvert: true, fin: fin.toISOString() };
+              localStorage.setItem('candidatureStatus', JSON.stringify(statut));
+              alert('Candidatures ouvertes pour ' + categorie.toUpperCase() + ' jusqu\'au ' + fin.toLocaleString());
+            };
+          }
+          const closeBtn = document.getElementById('closeBtn');
+          if (closeBtn) {
+            closeBtn.onclick = () => {
+              const cat = prompt("Catégorie à fermer (aes, club ou classe) ?");
+              const categorie = cat ? cat.toLowerCase() : "";
+              if (!['aes','club','classe'].includes(categorie)) return alert('Catégorie invalide');
+              const statut = JSON.parse(localStorage.getItem('candidatureStatus')) || {};
+              if (statut[categorie]) statut[categorie].ouvert = false;
+              localStorage.setItem('candidatureStatus', JSON.stringify(statut));
+              alert('Candidatures fermées pour ' + categorie.toUpperCase());
+            };
+          }
+          const statsBtn = document.getElementById('statsBtn');
+          if (statsBtn) statsBtn.onclick = () => alert('Statistiques des candidats');
           document.getElementById('deleteBtn').onclick = () => {
             if(confirm('Voulez-vous vraiment supprimer ?')) alert('Suppression effectuée');
           };


### PR DESCRIPTION
## Summary
- allow admin to choose category and end date for opening candidatures
- check if candidates exist before starting votes
- store candidature and vote status in localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68422fc27bbc8325ae0d110fb56efa55