### PR TITLE
Add club selection for starting elections

### DIFF
--- a/E-election/admin_accueil.html
+++ b/E-election/admin_accueil.html
@@ -42,6 +42,10 @@
             <option value="classe">Classe</option>
           </select>
         </div>
+        <div class="form-group" id="voteClubGroup" style="display:none;">
+          <label for="voteClub">Club</label>
+          <select id="voteClub"></select>
+        </div>
         <div class="form-actions">
           <button class="admin-btn" id="nextToDates">Suivant</button>
         </div>
@@ -58,6 +62,41 @@
         <div class="form-actions">
           <button class="admin-btn danger" id="cancelVoteModal">Annuler</button>
           <button class="admin-btn" id="validateVoteModal">Valider</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal pour démarrer les candidatures -->
+  <div id="startCandModal" class="modal">
+    <div class="modal-content">
+      <span class="close-btn" id="closeStartCand">&times;</span>
+      <div id="candStep1">
+        <div class="form-group">
+          <label for="candType">Catégorie</label>
+          <select id="candType">
+            <option value="" selected disabled>Choisir une catégorie</option>
+            <option value="aes">AES</option>
+            <option value="club">Club</option>
+            <option value="classe">Classe</option>
+          </select>
+        </div>
+        <div class="form-group" id="candClubGroup" style="display:none;">
+          <label for="candClub">Club</label>
+          <select id="candClub"></select>
+        </div>
+        <div class="form-actions">
+          <button class="admin-btn" id="candNextToDate">Suivant</button>
+        </div>
+      </div>
+      <div id="candStep2" style="display:none;">
+        <div class="form-group">
+          <label for="endCandDate">Date et heure de fin</label>
+          <input type="datetime-local" id="endCandDate">
+        </div>
+        <div class="form-actions">
+          <button class="admin-btn danger" id="cancelCandModal">Annuler</button>
+          <button class="admin-btn" id="validateCandModal">Valider</button>
         </div>
       </div>
     </div>

--- a/E-election/assets/js/state.js
+++ b/E-election/assets/js/state.js
@@ -1,6 +1,6 @@
 const defaultState = {
-  candidature: { active: false, category: null, endTime: null },
-  vote: { active: false, category: null, startTime: null, endTime: null }
+  candidature: { active: false, category: null, club: null, endTime: null },
+  vote: { active: false, category: null, club: null, startTime: null, endTime: null }
 };
 
 function loadState() {
@@ -17,37 +17,41 @@ function getState() {
   let changed = false;
   if (state.candidature.active && Date.now() > state.candidature.endTime) {
     state.candidature.active = false;
+    state.candidature.club = null;
     changed = true;
   }
   if (state.vote.active && Date.now() > state.vote.endTime) {
     state.vote.active = false;
+    state.vote.club = null;
     changed = true;
   }
   if (changed) saveState(state);
   return state;
 }
 
-function startCandidature(category, endTime) {
+function startCandidature(category, endTime, club = null) {
   const state = getState();
-  state.candidature = { active: true, category, endTime };
+  state.candidature = { active: true, category, club, endTime };
   saveState(state);
 }
 
 function endCandidature() {
   const state = getState();
   state.candidature.active = false;
+  state.candidature.club = null;
   saveState(state);
 }
 
-function startVote(category, startTime, endTime) {
+function startVote(category, startTime, endTime, club = null) {
   const state = getState();
-  state.vote = { active: true, category, startTime, endTime };
+  state.vote = { active: true, category, club, startTime, endTime };
   saveState(state);
 }
 
 function endVote() {
   const state = getState();
   state.vote.active = false;
+  state.vote.club = null;
   saveState(state);
 }
 


### PR DESCRIPTION
## Summary
- support choosing a club when launching votes or candidatures
- include dropdown to pick the club and new modal for candidatures
- track selected club in election state

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842409125bc83258d97a0460ebf765d