### PR TITLE
Add candidature start time management

### DIFF
--- a/E-election/admin_accueil.html
+++ b/E-election/admin_accueil.html
@@ -91,6 +91,10 @@
       </div>
       <div id="candStep2" style="display:none;">
         <div class="form-group">
+          <label for="startCandDate">Date et heure de début</label>
+          <input type="datetime-local" id="startCandDate">
+        </div>
+        <div class="form-group">
           <label for="endCandDate">Date et heure de fin</label>
           <input type="datetime-local" id="endCandDate">
         </div>

--- a/E-election/assets/js/admin_accueil.js
+++ b/E-election/assets/js/admin_accueil.js
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const candType = document.getElementById('candType');
   const candClubGroup = document.getElementById('candClubGroup');
   const candClub = document.getElementById('candClub');
+  const startCandDate = document.getElementById('startCandDate');
   const endCandDate = document.getElementById('endCandDate');
 
   function loadClubs(select) {
@@ -54,6 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
     candType.value = '';
     if (candClubGroup) candClubGroup.style.display = 'none';
     if (candClub) candClub.innerHTML = '';
+    if (startCandDate) startCandDate.value = '';
     endCandDate.value = '';
   }
 
@@ -109,11 +111,12 @@ document.addEventListener('DOMContentLoaded', () => {
   if (validateCandModal) validateCandModal.onclick = () => {
     const categorie = candType.value;
     const club = candType.value === 'club' ? candClub.value : null;
+    const debut = Date.parse(startCandDate.value);
     const fin = Date.parse(endCandDate.value);
     if (!categorie) { alert('Catégorie manquante'); return; }
     if (categorie === 'club' && !club) { alert('Sélectionnez un club'); return; }
-    if (isNaN(fin)) { alert('Date invalide'); return; }
-    startCandidature(categorie, fin, club);
+    if (isNaN(debut) || isNaN(fin) || debut >= fin) { alert('Dates invalides'); return; }
+    startCandidature(categorie, debut, fin, club);
     alert('Candidatures ouvertes pour ' + (categorie === 'club' ? club : categorie).toUpperCase());
     startCandModal.style.display = 'none';
     resetCandModal();

--- a/E-election/assets/js/campagne.js
+++ b/E-election/assets/js/campagne.js
@@ -323,8 +323,9 @@ window.addEventListener('DOMContentLoaded', function() {
         return;
     } else if (info) {
         const state = getState();
+        const deb = new Date(state.candidature.startTime);
         const end = new Date(state.candidature.endTime);
-        info.textContent = 'Fin des candidatures : ' + end.toLocaleString();
+        info.textContent = 'Candidatures du ' + deb.toLocaleString() + ' au ' + end.toLocaleString();
     }
 
     const select = document.getElementById('type-election');

--- a/E-election/assets/js/candidat.js
+++ b/E-election/assets/js/candidat.js
@@ -86,8 +86,10 @@ document.addEventListener('DOMContentLoaded', () => {
   } else {
     const state = getState();
     if (info) {
+      const deb = new Date(state.candidature.startTime);
       const end = new Date(state.candidature.endTime);
-      info.textContent = 'Fin des candidatures : ' + end.toLocaleString();
+      info.textContent =
+        'Candidatures du ' + deb.toLocaleString() + ' au ' + end.toLocaleString();
     }
   }
   const electionButtons = document.querySelectorAll('.election-btn');

--- a/E-election/assets/js/state.js
+++ b/E-election/assets/js/state.js
@@ -1,5 +1,11 @@
 const defaultState = {
-  candidature: { active: false, category: null, club: null, endTime: null },
+  candidature: {
+    active: false,
+    category: null,
+    club: null,
+    startTime: null,
+    endTime: null
+  },
   vote: { active: false, category: null, club: null, startTime: null, endTime: null }
 };
 
@@ -29,9 +35,9 @@ function getState() {
   return state;
 }
 
-function startCandidature(category, endTime, club = null) {
+function startCandidature(category, startTime, endTime, club = null) {
   const state = getState();
-  state.candidature = { active: true, category, club, endTime };
+  state.candidature = { active: true, category, club, startTime, endTime };
   saveState(state);
 }
 
@@ -39,6 +45,7 @@ function endCandidature() {
   const state = getState();
   state.candidature.active = false;
   state.candidature.club = null;
+  state.candidature.startTime = null;
   saveState(state);
 }
 
@@ -57,7 +64,11 @@ function endVote() {
 
 function isCandidatureActive() {
   const s = getState();
-  return s.candidature.active && Date.now() < s.candidature.endTime;
+  return (
+    s.candidature.active &&
+    Date.now() >= s.candidature.startTime &&
+    Date.now() < s.candidature.endTime
+  );
 }
 
 function isVoteActive() {


### PR DESCRIPTION
## Summary
- include a start date for candidature periods
- display candidature period in candidate and campaign pages
- add start date field to admin modal and validation logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68424372bc9c83259bc697c9b7480310