### PR TITLE
Fix candidature relaunch and candidate page

### DIFF
--- a/E-election/assets/js/admin_accueil.js
+++ b/E-election/assets/js/admin_accueil.js
@@ -374,6 +374,11 @@ document.addEventListener('DOMContentLoaded', () => {
         setTimeout(() => {
 
           document.getElementById('startBtn').onclick = () => {
+            const state = getState();
+            if (state.candidature.active && Date.now() < state.candidature.endTime) {
+              alert('Une session de candidatures est déjà en cours');
+              return;
+            }
             startCandModal.style.display = 'flex';
           };
           document.getElementById('closeBtn').onclick = () => { endCandidature(); alert('Candidatures fermées'); };

--- a/E-election/pages/candidat.html
+++ b/E-election/pages/candidat.html
@@ -94,7 +94,7 @@
         includeComponent('#header', '../components/header.html');
         includeComponent('#footer', '../components/footer.html');
     </script>
-
-  <script src="../assets/js/candidat.js"></script>
+    <script src="../assets/js/state.js"></script>
+    <script src="../assets/js/candidat.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- avoid opening a new candidature session when one is running
- load `state.js` directly on the candidate page so candidatures can be created

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68424b7dad44832589562278c55b59eb