### PR TITLE
Implement per-category candidature sessions

### DIFF
--- a/E-election/assets/js/admin_accueil.js
+++ b/E-election/assets/js/admin_accueil.js
@@ -116,6 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!categorie) { alert('Catégorie manquante'); return; }
     if (categorie === 'club' && !club) { alert('Sélectionnez un club'); return; }
     if (isNaN(debut) || isNaN(fin) || debut >= fin) { alert('Dates invalides'); return; }
+    if (isCandidatureActive(categorie)) { alert('Cette catégorie possède déjà une session active'); return; }
     startCandidature(categorie, debut, fin, club);
     alert('Candidatures ouvertes pour ' + (categorie === 'club' ? club : categorie).toUpperCase());
     startCandModal.style.display = 'none';
@@ -374,14 +375,15 @@ document.addEventListener('DOMContentLoaded', () => {
         setTimeout(() => {
 
           document.getElementById('startBtn').onclick = () => {
-            const state = getState();
-            if (state.candidature.active && Date.now() < state.candidature.endTime) {
-              alert('Une session de candidatures est déjà en cours');
-              return;
-            }
             startCandModal.style.display = 'flex';
           };
-          document.getElementById('closeBtn').onclick = () => { endCandidature(); alert('Candidatures fermées'); };
+          document.getElementById('closeBtn').onclick = () => {
+            const cat = prompt('Catégorie à fermer (aes, club, classe) :');
+            if (!cat || !['aes','club','classe'].includes(cat.toLowerCase())) return;
+            if (!isCandidatureActive(cat.toLowerCase())) { alert('Pas de session ouverte pour cette catégorie'); return; }
+            endCandidature(cat.toLowerCase());
+            alert('Candidatures fermées pour ' + cat.toUpperCase());
+          };
           document.getElementById('statsBtn').onclick = () => alert('Statistiques des candidats');
           document.getElementById('deleteBtn').onclick = () => {
             if(confirm('Voulez-vous vraiment supprimer ?')) alert('Suppression effectuée');

--- a/E-election/assets/js/campagne.js
+++ b/E-election/assets/js/campagne.js
@@ -294,6 +294,19 @@ function afficherClasse(index = pageClasse) {
 // ===============================
 document.getElementById('type-election').addEventListener('change', function () {
     const selection = this.value;
+    const info = document.getElementById('campagne-info');
+    if (!isCandidatureActive(selection)) {
+        if (info) info.textContent = 'Aucune campagne en cours pour ' + selection.toUpperCase();
+        document.getElementById('contenu-election').innerHTML = '';
+        return;
+    }
+    const state = getState();
+    const c = selection === 'club' ? state.candidature.club : state.candidature[selection];
+    if (info) {
+        const deb = new Date(c.startTime);
+        const end = new Date(c.endTime);
+        info.textContent = 'Candidatures du ' + deb.toLocaleString() + ' au ' + end.toLocaleString();
+    }
     if (selection === 'aes') {
         pageAES = parseInt(localStorage.getItem('pageAES')) || 0;
         afficherAES(pageAES);
@@ -304,7 +317,6 @@ document.getElementById('type-election').addEventListener('change', function () 
         pageClasse = parseInt(localStorage.getItem('pageClasse')) || 0;
         afficherClasse(pageClasse);
     } else {
-        // Cas par défaut : message d'attente
         document.getElementById('contenu-election').innerHTML = `
             <h2>Élections ${selection.toUpperCase()}</h2>
             <p>Les détails des élections pour ${selection} seront bientôt disponibles.</p>
@@ -317,18 +329,18 @@ document.getElementById('type-election').addEventListener('change', function () 
 // ===============================
 window.addEventListener('DOMContentLoaded', function() {
     const info = document.getElementById('campagne-info');
-    if (!isCandidatureActive()) {
-        if (info) info.textContent = 'Aucune campagne en cours.';
+    const select = document.getElementById('type-election');
+    if (!isCandidatureActive(select.value)) {
+        if (info) info.textContent = 'Aucune campagne en cours pour ' + select.value.toUpperCase();
         document.getElementById('contenu-election').innerHTML = '';
         return;
     } else if (info) {
         const state = getState();
-        const deb = new Date(state.candidature.startTime);
-        const end = new Date(state.candidature.endTime);
+        const c = select.value === 'club' ? state.candidature.club : state.candidature[select.value];
+        const deb = new Date(c.startTime);
+        const end = new Date(c.endTime);
         info.textContent = 'Candidatures du ' + deb.toLocaleString() + ' au ' + end.toLocaleString();
     }
-
-    const select = document.getElementById('type-election');
     if (select.value === 'aes') {
         pageAES = parseInt(localStorage.getItem('pageAES')) || 0;
         afficherAES(pageAES);

--- a/E-election/assets/js/candidat.js
+++ b/E-election/assets/js/candidat.js
@@ -80,16 +80,22 @@ function chargerPostesClub(club) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const info = document.getElementById('candidature-info');
-  if (!isCandidatureActive()) {
-    if (info) info.textContent = 'Les candidatures ne sont pas ouvertes.';
-    return;
-  } else {
-    const state = getState();
-    if (info) {
-      const deb = new Date(state.candidature.startTime);
-      const end = new Date(state.candidature.endTime);
-      info.textContent =
-        'Candidatures du ' + deb.toLocaleString() + ' au ' + end.toLocaleString();
+  const state = getState();
+  const msgs = [];
+  ['aes','classe','club'].forEach(cat => {
+    if (isCandidatureActive(cat)) {
+      const c = cat === 'club' ? state.candidature.club : state.candidature[cat];
+      const deb = new Date(c.startTime);
+      const end = new Date(c.endTime);
+      const label = cat === 'club' ? c.club : cat.toUpperCase();
+      msgs.push(`<strong>${label}</strong> : du ${deb.toLocaleString()} au ${end.toLocaleString()}`);
+    }
+  });
+  if (info) {
+    if (msgs.length === 0) {
+      info.textContent = 'Les candidatures ne sont pas ouvertes.';
+    } else {
+      info.innerHTML = msgs.join('<br>');
     }
   }
   const electionButtons = document.querySelectorAll('.election-btn');
@@ -100,7 +106,19 @@ document.addEventListener('DOMContentLoaded', () => {
   electionButtons.forEach(btn => {
     btn.addEventListener('click', (e) => {
       const type = e.target.textContent.trim().toLowerCase();
+      if (!isCandidatureActive(type)) {
+        alert('Les candidatures pour ' + type.toUpperCase() + ' ne sont pas ouvertes.');
+        return;
+      }
       document.getElementById('electionType').value = e.target.textContent;
+      const state = getState();
+      const c = type === 'club' ? state.candidature.club : state.candidature[type];
+      if (info) {
+        const deb = new Date(c.startTime);
+        const end = new Date(c.endTime);
+        const label = type === 'club' ? c.club : type.toUpperCase();
+        info.innerHTML = `<strong>${label}</strong> : du ${deb.toLocaleString()} au ${end.toLocaleString()}`;
+      }
       form.style.display = 'block';
       if (type === 'club') {
         if (clubGroup) clubGroup.style.display = 'block';


### PR DESCRIPTION
## Summary
- maintain candidature status per category in state.js
- prevent overlapping sessions and disallow closing non-active category
- show active periods per category on candidate and campaign pages
- restrict candidature form based on active category
- update admin actions to manage sessions individually

## Testing
- `node --check E-election/assets/js/state.js`
- `node --check E-election/assets/js/candidat.js`
- `node --check E-election/assets/js/campagne.js`
- `node --check E-election/assets/js/admin_accueil.js`

------
https://chatgpt.com/codex/tasks/task_e_68424d5fbb78832597560660b2c5310c