### PR TITLE
Fix header activation with state events

### DIFF
--- a/E-election/assets/js/header.js
+++ b/E-election/assets/js/header.js
@@ -65,3 +65,4 @@
   }
 
   document.addEventListener('DOMContentLoaded', updateNavVisibility);
+  document.addEventListener('stateChanged', updateNavVisibility);

--- a/E-election/assets/js/state.js
+++ b/E-election/assets/js/state.js
@@ -14,6 +14,8 @@ function loadState() {
 
 function saveState(state) {
   localStorage.setItem('electionState', JSON.stringify(state));
+  // Notifie les autres scripts qu'un changement a été effectué
+  document.dispatchEvent(new Event('stateChanged'));
 }
 
 function getState() {


### PR DESCRIPTION
## Summary
- dispatch a `stateChanged` event when election state updates
- update navigation visibility when `stateChanged` is emitted

## Testing
- `node -c E-election/assets/js/state.js`
- `node -c E-election/assets/js/header.js`

------
https://chatgpt.com/codex/tasks/task_e_684250d25164832598770523fcadb71c