### PR TITLE
Refactor voting pages

### DIFF
--- a/E-election/admin_accueil.html
+++ b/E-election/admin_accueil.html
@@ -42,10 +42,6 @@
             <option value="classe">Classe</option>
           </select>
         </div>
-        <div class="form-group" id="voteClubGroup" style="display:none;">
-          <label for="voteClub">Club</label>
-          <select id="voteClub"></select>
-        </div>
         <div class="form-actions">
           <button class="admin-btn" id="nextToDates">Suivant</button>
         </div>
@@ -80,10 +76,6 @@
             <option value="club">Club</option>
             <option value="classe">Classe</option>
           </select>
-        </div>
-        <div class="form-group" id="candClubGroup" style="display:none;">
-          <label for="candClub">Club</label>
-          <select id="candClub"></select>
         </div>
         <div class="form-actions">
           <button class="admin-btn" id="candNextToDate">Suivant</button>

--- a/E-election/assets/css/campagne.css
+++ b/E-election/assets/css/campagne.css
@@ -9,6 +9,17 @@
     border-radius: var(--radius);
     box-shadow: 0 4px 24px 0 rgba(37, 99, 235, 0.10);
 }
+
+#campagne-info {
+    background: var(--primary-light);
+    border-left: 4px solid var(--primary);
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+    text-align: center;
+    border-radius: var(--radius);
+    font-weight: 600;
+    color: var(--primary);
+}
 .candidats, .membres {
     display: flex;
     flex-wrap: wrap;

--- a/E-election/assets/css/candidat.css
+++ b/E-election/assets/css/candidat.css
@@ -35,6 +35,17 @@
   color: var(--white);
 }
 
+#candidature-info {
+  background: var(--primary-light);
+  border-left: 4px solid var(--primary);
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  text-align: center;
+  border-radius: var(--radius);
+  font-weight: 600;
+  color: var(--primary);
+}
+
 #newCandidature {
   background: var(--white);
   padding: 1.5rem;

--- a/E-election/assets/css/vote.css
+++ b/E-election/assets/css/vote.css
@@ -12,6 +12,17 @@
     flex-direction: column;
     align-items: center;
 }
+
+#vote-info {
+    background: var(--primary-light);
+    border-left: 4px solid var(--primary);
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+    text-align: center;
+    border-radius: var(--radius);
+    font-weight: 600;
+    color: var(--primary);
+}
 #contenu-vote {
     background-color: var(--white);
     padding: 2rem 1.2rem;

--- a/E-election/assets/js/admin_accueil.js
+++ b/E-election/assets/js/admin_accueil.js
@@ -8,8 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const step1 = document.getElementById('step1');
   const step2 = document.getElementById('step2');
   const voteType = document.getElementById('voteType');
-  const voteClubGroup = document.getElementById('voteClubGroup');
-  const voteClub = document.getElementById('voteClub');
+  const voteClubGroup = null;
+  const voteClub = null;
   const startVoteInput = document.getElementById('startVote');
   const endVoteInput = document.getElementById('endVote');
 
@@ -22,8 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const candStep1 = document.getElementById('candStep1');
   const candStep2 = document.getElementById('candStep2');
   const candType = document.getElementById('candType');
-  const candClubGroup = document.getElementById('candClubGroup');
-  const candClub = document.getElementById('candClub');
+  const candClubGroup = null;
+  const candClub = null;
   const startCandDate = document.getElementById('startCandDate');
   const endCandDate = document.getElementById('endCandDate');
 
@@ -43,8 +43,6 @@ document.addEventListener('DOMContentLoaded', () => {
     step1.style.display = 'block';
     step2.style.display = 'none';
     voteType.value = '';
-    if (voteClubGroup) voteClubGroup.style.display = 'none';
-    if (voteClub) voteClub.innerHTML = '';
     startVoteInput.value = '';
     endVoteInput.value = '';
   }
@@ -53,72 +51,55 @@ document.addEventListener('DOMContentLoaded', () => {
     candStep1.style.display = 'block';
     candStep2.style.display = 'none';
     candType.value = '';
-    if (candClubGroup) candClubGroup.style.display = 'none';
-    if (candClub) candClub.innerHTML = '';
     if (startCandDate) startCandDate.value = '';
     endCandDate.value = '';
   }
 
   if (closeStartVotes) closeStartVotes.onclick = () => { startVotesModal.style.display = 'none'; resetVoteModal(); };
   if (cancelVoteModal) cancelVoteModal.onclick = () => { startVotesModal.style.display = 'none'; resetVoteModal(); };
-  if (voteType) voteType.onchange = () => {
-    if (voteType.value === 'club') {
-      loadClubs(voteClub);
-      if (voteClubGroup) voteClubGroup.style.display = 'block';
-    } else if (voteClubGroup) {
-      voteClubGroup.style.display = 'none';
-    }
-  };
+  if (voteType) voteType.onchange = () => {};
   if (nextToDates) nextToDates.onclick = () => {
     if (!voteType.value) { alert('Choisissez un type'); return; }
-    if (voteType.value === 'club' && !voteClub.value) { alert('Sélectionnez un club'); return; }
     step1.style.display = 'none';
     step2.style.display = 'block';
   };
   if (validateVoteModal) validateVoteModal.onclick = () => {
     const categorie = voteType.value;
-    const club = voteType.value === 'club' ? voteClub.value : null;
+    const club = null;
     const debut = Date.parse(startVoteInput.value);
     const fin = Date.parse(endVoteInput.value);
     if (!categorie) { alert('Type manquant'); return; }
-    if (categorie === 'club' && !club) { alert('Sélectionnez un club'); return; }
     if (isNaN(debut) || isNaN(fin) || debut >= fin) { alert('Dates invalides'); return; }
     const candidats = JSON.parse(localStorage.getItem('candidatures')) || [];
-    const existe = candidats.some(c => (c.type || '').toLowerCase() === categorie && (categorie !== 'club' || c.club === club));
+    const existe = candidats.some(c => (c.type || '').toLowerCase() === categorie);
+    const state = getState();
+    const candActive = categorie === 'club' ? state.candidature.club.active : state.candidature[categorie].active;
+    if (candActive) { alert('Les candidatures pour cette catégorie ne sont pas terminées'); return; }
     if (!existe) { alert('Pas possible car pas de candidats'); return; }
     startVote(categorie, debut, fin, club);
-    alert('Votes démarrés pour ' + (categorie === 'club' ? club : categorie).toUpperCase());
+    alert('Votes démarrés pour ' + categorie.toUpperCase());
     startVotesModal.style.display = 'none';
     resetVoteModal();
   };
 
   if (closeStartCand) closeStartCand.onclick = () => { startCandModal.style.display = 'none'; resetCandModal(); };
   if (cancelCandModal) cancelCandModal.onclick = () => { startCandModal.style.display = 'none'; resetCandModal(); };
-  if (candType) candType.onchange = () => {
-    if (candType.value === 'club') {
-      loadClubs(candClub);
-      if (candClubGroup) candClubGroup.style.display = 'block';
-    } else if (candClubGroup) {
-      candClubGroup.style.display = 'none';
-    }
-  };
+  if (candType) candType.onchange = () => {};
   if (candNextToDate) candNextToDate.onclick = () => {
     if (!candType.value) { alert('Choisissez une catégorie'); return; }
-    if (candType.value === 'club' && !candClub.value) { alert('Sélectionnez un club'); return; }
     candStep1.style.display = 'none';
     candStep2.style.display = 'block';
   };
   if (validateCandModal) validateCandModal.onclick = () => {
     const categorie = candType.value;
-    const club = candType.value === 'club' ? candClub.value : null;
+    const club = null;
     const debut = Date.parse(startCandDate.value);
     const fin = Date.parse(endCandDate.value);
     if (!categorie) { alert('Catégorie manquante'); return; }
-    if (categorie === 'club' && !club) { alert('Sélectionnez un club'); return; }
     if (isNaN(debut) || isNaN(fin) || debut >= fin) { alert('Dates invalides'); return; }
     if (isCandidatureActive(categorie)) { alert('Cette catégorie possède déjà une session active'); return; }
     startCandidature(categorie, debut, fin, club);
-    alert('Candidatures ouvertes pour ' + (categorie === 'club' ? club : categorie).toUpperCase());
+    alert('Candidatures ouvertes pour ' + categorie.toUpperCase());
     startCandModal.style.display = 'none';
     resetCandModal();
   };

--- a/E-election/assets/js/candidat.js
+++ b/E-election/assets/js/candidat.js
@@ -78,7 +78,7 @@ function chargerPostesClub(club) {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function updateInfo() {
   const info = document.getElementById('candidature-info');
   const state = getState();
   const msgs = [];
@@ -98,6 +98,10 @@ document.addEventListener('DOMContentLoaded', () => {
       info.innerHTML = msgs.join('<br>');
     }
   }
+}
+
+function initCandidatPage() {
+  updateInfo();
   const electionButtons = document.querySelectorAll('.election-btn');
   const form = document.getElementById('newCandidature');
   const clubGroup = document.getElementById('clubGroup');
@@ -120,6 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
         info.innerHTML = `<strong>${label}</strong> : du ${deb.toLocaleString()} au ${end.toLocaleString()}`;
       }
       form.style.display = 'block';
+      localStorage.setItem('lastCandidatureType', type);
       if (type === 'club') {
         if (clubGroup) clubGroup.style.display = 'block';
         chargerClubs();
@@ -135,6 +140,12 @@ document.addEventListener('DOMContentLoaded', () => {
     clubSelect.addEventListener('change', (e) => {
       chargerPostesClub(e.target.value);
     });
+  }
+
+  const last = localStorage.getItem('lastCandidatureType');
+  if (last) {
+    const btn = Array.from(electionButtons).find(b => b.textContent.trim().toLowerCase() === last);
+    if (btn && isCandidatureActive(last)) btn.click();
   }
 
   document.getElementById('validerCandidatureBtn').addEventListener('click', () => {
@@ -158,4 +169,8 @@ document.addEventListener('DOMContentLoaded', () => {
     
     window.location.href = 'mes-candidatures.html';
   });
-});
+
+}
+
+document.addEventListener('DOMContentLoaded', initCandidatPage);
+document.addEventListener('stateChanged', initCandidatPage);

--- a/E-election/assets/js/vote.js
+++ b/E-election/assets/js/vote.js
@@ -337,6 +337,7 @@ function afficherClasse(index = pageClasse) {
 // Gestion du selecteur de type d'élection
 // ===============================
 document.getElementById('type-election').addEventListener('change', function () {
+    localStorage.setItem('lastVoteType', this.value);
     const selection = this.value;
     if (selection === 'aes') {
         pageAES = 0;
@@ -358,8 +359,11 @@ document.getElementById('type-election').addEventListener('change', function () 
 // ===============================
 // Affichage initial à l'ouverture de la page
 // ===============================
-window.addEventListener('DOMContentLoaded', function() {
+function initVotePage() {
     const info = document.getElementById('vote-info');
+    const select = document.getElementById('type-election');
+    const stored = localStorage.getItem('lastVoteType');
+    if (stored) select.value = stored;
     if (!isVoteActive()) {
         if (info) info.textContent = 'Aucun vote en cours.';
         document.getElementById('contenu-vote').innerHTML = '';
@@ -370,17 +374,8 @@ window.addEventListener('DOMContentLoaded', function() {
         const fin = new Date(state.vote.endTime);
         info.textContent = 'Vote du ' + deb.toLocaleString() + ' au ' + fin.toLocaleString();
     }
-    const select = document.getElementById('type-election');
-    if (select.value === 'aes') {
-        afficherAES(pageAES);
-    } else if (select.value === 'club') {
-        afficherClub(pageClub);
-    } else if (select.value === 'classe') {
-        afficherClasse(pageClasse);
-    } else {
-        document.getElementById('contenu-vote').innerHTML = `
-            <h2>Élections ${select.value.toUpperCase()}</h2>
-            <p>Les détails des élections pour ${select.value} seront bientôt disponibles.</p>
-        `;
-    }
-});
+    select.dispatchEvent(new Event('change'));
+}
+
+document.addEventListener('DOMContentLoaded', initVotePage);
+document.addEventListener('stateChanged', initVotePage);


### PR DESCRIPTION
## Summary
- style info banners on candidate, vote and campaign pages
- persist filter selections for candidate and vote views
- reload state when election data changes
- simplify admin modals and allow starting votes only after candidatures close

## Testing
- `npm test` *(fails: no package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842ecc43b00832598486852d929e5fd