### PR TITLE
Fix candidate page dropdowns

### DIFF
--- a/E-election/pages/candidat.html
+++ b/E-election/pages/candidat.html
@@ -27,10 +27,6 @@
       </div>
 
       <form id="newCandidature" style="display: none;">
-        <div class="form-group">
-          <label for="electionType">Type d'élection:</label>
-          <input type="text" id="electionType" readonly>
-        </div>
         
         <div class="form-group">
           <label for="nom">Nom:</label>
@@ -60,8 +56,8 @@
         </div>
 
         <div class="form-group">
-          <label for="poste">Poste:</label>
-          <select id="poste" required>
+          <label for="posteSelect">Poste:</label>
+          <select id="posteSelect" required>
             <option value="">-- Sélectionnez un poste --</option>
           </select>
         </div>


### PR DESCRIPTION
## Summary
- fix candidate form to actually populate poste/club dropdowns
- remove election type input and rely on the filter buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68432d0ee448832594bf08d56f43c574