### PR TITLE
Fix vote page refresh on interaction

### DIFF
--- a/E-election/assets/js/vote.js
+++ b/E-election/assets/js/vote.js
@@ -88,7 +88,7 @@ function hasVotedAll(type) {
 }
 
 // Récupère l'état des sessions
-function getState() {
+function getVoteState() {
     return {
         vote: JSON.parse(localStorage.getItem('votesSessions')) || {}
     };
@@ -100,7 +100,7 @@ function getState() {
 function updateVoteInfo(type) {
     const info = document.getElementById('vote-info');
     if (!info) return;
-    const state = getState();
+    const state = getVoteState();
     const session = state.vote[type];
     if (!session || !session.active) {
         info.textContent = `Aucune session de vote ${type.toUpperCase()} ouverte.`;
@@ -147,7 +147,7 @@ function afficherAES(index = 0) {
     localStorage.setItem('votePageAES', pageAES);
     const contenu = document.getElementById('contenu-vote');
     updateVoteInfo('aes');
-    const state = getState();
+    const state = getVoteState();
     const v = state.vote['aes'];
     let periode = '';
     if (v) {
@@ -256,7 +256,7 @@ function afficherClub(index = 0) {
     localStorage.setItem('votePageClub', pageClub);
     const contenu = document.getElementById('contenu-vote');
     updateVoteInfo('club');
-    const state = getState();
+    const state = getVoteState();
     const v = state.vote['club'];
     let periode = '';
     if (v) {
@@ -376,7 +376,7 @@ function afficherClasse(index = 0) {
     localStorage.setItem('votePageClasse', pageClasse);
     const contenu = document.getElementById('contenu-vote');
     updateVoteInfo('classe');
-    const state = getState();
+    const state = getVoteState();
     const v = state.vote['classe'];
     let periode = '';
     if (v) {


### PR DESCRIPTION
## Summary
- avoid global `getState` name collision by renaming the vote page function to `getVoteState`
- use the new function throughout `vote.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684358c32c3c8325a63855c1012d6d03