### PR TITLE
Update voting result and statistics behavior

### DIFF
--- a/E-election/assets/js/header.js
+++ b/E-election/assets/js/header.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const canSeeStats = state.vote.category && userHasVoted(state.vote.category);
     toggleLink('a[href$="statistique.html"]', !canSeeStats);
-    const showResults = state.vote.category && !voteOn && state.vote.endTime && Date.now() >= state.vote.endTime;
+    const showResults = state.vote.category && !voteOn && state.vote.endTime && Date.now() >= state.vote.endTime && Date.now() <= state.vote.endTime + 7 * 24 * 60 * 60 * 1000;
     toggleLink('a[href$="resultat.html"]', !showResults);
   }
 

--- a/E-election/assets/js/resultat.js
+++ b/E-election/assets/js/resultat.js
@@ -133,23 +133,49 @@ function afficherResultats(type) {
 // ===============================
 // Gestion du selecteur de type d'élection
 // ===============================
+function formatDuration(ms) {
+    const totalSec = Math.floor(ms / 1000);
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    return `${h}h ${m}m`;
+}
+
+function updateResultats(type) {
+    const info = document.getElementById('resultats');
+    const state = getState();
+
+    if (!state.vote.category || state.vote.category !== type) {
+        info.innerHTML = '<p>Aucune session de vote ouverte pour cette catégorie.</p>';
+        return;
+    }
+
+    const now = Date.now();
+
+    if (state.vote.active && now < state.vote.endTime) {
+        const remaining = formatDuration(state.vote.endTime - now);
+        info.innerHTML = `<p>Pas de résultats pour le moment. Session ouverte (fin dans ${remaining}).</p>`;
+        return;
+    }
+
+    if (now > state.vote.endTime + 7 * 24 * 60 * 60 * 1000) {
+        info.innerHTML = '<p>Les résultats ne sont plus disponibles.</p>';
+        return;
+    }
+
+    afficherResultats(type);
+}
+
 document.getElementById('type-result').addEventListener('change', function () {
-    afficherResultats(this.value);
+    updateResultats(this.value);
 });
 
 // ===============================
 // Affichage initial à l'ouverture de la page
 // ===============================
 window.addEventListener('DOMContentLoaded', function() {
-    const state = getState();
-    const info = document.getElementById('resultats');
-    if (isVoteActive()) {
-        if (info) info.innerHTML = '<p>Les résultats seront disponibles à la fin des votes.</p>';
-        return;
+    loadCandidates();
+    const select = document.getElementById('type-result');
+    if (select) {
+        updateResultats(select.value);
     }
-    if (!state.vote.endTime || Date.now() < state.vote.endTime) {
-        if (info) info.innerHTML = '<p>Aucun résultat disponible.</p>';
-        return;
-    }
-    afficherResultats(document.getElementById('type-result').value);
 });

--- a/E-election/assets/js/statistique.js
+++ b/E-election/assets/js/statistique.js
@@ -195,15 +195,16 @@ function afficherStats(type) {
     else if (type === 'classe') data = donneesClasse;
     else return;
 
-    // Gestion des cas d'accès
-    if (!isVoteActive(type)) {
-        document.getElementById('stats-global').innerHTML = `<p style="color:red;">Pas de vote démarré pour cette catégorie, donc pas de statistiques.</p>`;
+    // L'utilisateur doit avoir voté pour tous les postes de la catégorie
+    if (!hasVotedAll(type)) {
+        document.getElementById('stats-global').innerHTML = `<p style="color:orange;">Vous devez voter pour tous les postes de cette catégorie pour consulter les statistiques.</p>`;
         document.getElementById('stats-graph').style.display = "none";
         document.getElementById('stats-detail').innerHTML = "";
         return;
     }
-    if (!hasVotedAll(type)) {
-        document.getElementById('stats-global').innerHTML = `<p style="color:orange;">Vote non fini pour cette catégorie.<br>Finissez tous les votes pour voir les statistiques.</p>`;
+
+    if (!data || data.length === 0) {
+        document.getElementById('stats-global').innerHTML = `<p style="color:red;">Aucune donnée disponible pour cette catégorie.</p>`;
         document.getElementById('stats-graph').style.display = "none";
         document.getElementById('stats-detail').innerHTML = "";
         return;


### PR DESCRIPTION
## Summary
- adjust stats access logic to only require that the user completed voting for the category
- display relevant messages when there is no data
- show remaining time for result availability and limit access to one week after vote end
- restrict result navigation link accordingly

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68441b9f93248325bc96b989511d33bd