### PR TITLE
Add committee controls on profile page

### DIFF
--- a/E-election/assets/css/profil.css
+++ b/E-election/assets/css/profil.css
@@ -13,3 +13,25 @@
 .profile-info p {
   margin: 0.5rem 0;
 }
+
+.profile-photo {
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+  margin: 0 auto 1rem auto;
+}
+
+.committee-actions {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.committee-section {
+  margin-top: 1.5rem;
+}
+
+.committee-section button {
+  margin: 0.25rem;
+}

--- a/E-election/assets/js/moi.js
+++ b/E-election/assets/js/moi.js
@@ -1,18 +1,106 @@
 document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('profileContainer');
+  const actionsContainer = document.getElementById('committeeActions');
   const userData = JSON.parse(localStorage.getItem('currentUser'));
-  if (userData) {
-    const inscription = userData.inscritDepuis ? new Date(userData.inscritDepuis).toLocaleDateString() : '';
-    container.innerHTML = `
-      <h2>Mon profil</h2>
-      <div class="profile-info">
-        <p><strong>Nom d'utilisateur:</strong> ${userData.username}</p>
-        <p><strong>Email:</strong> ${userData.email}</p>
-        <p><strong>Classe:</strong> ${userData.classe}</p>
-        <p><strong>Inscrit depuis:</strong> ${inscription}</p>
-      </div>
-    `;
-  } else {
-    container.innerHTML = '<p>Aucun utilisateur connect\u00e9.</p>';
+  if (!userData) {
+    container.innerHTML = '<p>Aucun utilisateur connecté.</p>';
+    return;
   }
+
+  const inscription = userData.inscritDepuis ? new Date(userData.inscritDepuis).toLocaleDateString() : '';
+  container.innerHTML = `
+    <h2>Mon profil</h2>
+    <div class="profile-info">
+      ${userData.photo ? `<img src="${userData.photo}" class="profile-photo" alt="photo">` : ''}
+      ${userData.nom ? `<p><strong>Nom:</strong> ${userData.nom}</p>` : ''}
+      ${userData.prenom ? `<p><strong>Prénom:</strong> ${userData.prenom}</p>` : ''}
+      <p><strong>Nom d'utilisateur:</strong> ${userData.username}</p>
+      <p><strong>Email:</strong> ${userData.email}</p>
+      ${userData.classe ? `<p><strong>Classe:</strong> ${userData.classe}</p>` : ''}
+      ${userData.nationalite ? `<p><strong>Nationalité:</strong> ${userData.nationalite}</p>` : ''}
+      <p><strong>Inscrit depuis:</strong> ${inscription}</p>
+    </div>
+  `;
+
+  showCommitteeActions(userData, actionsContainer);
 });
+
+function showCommitteeActions(user, container) {
+  const comites = JSON.parse(localStorage.getItem('comites')) || {};
+  const categories = Object.keys(comites).filter(cat =>
+    (comites[cat] || []).some(m => m.email === user.email)
+  );
+  if (categories.length === 0) return;
+
+  categories.forEach(cat => {
+    const section = document.createElement('div');
+    section.className = 'committee-section';
+    section.innerHTML = `
+      <h3>${cat.toUpperCase()}</h3>
+      <button class="admin-btn" data-action="startCand" data-cat="${cat}">Démarrer candidature</button>
+      <button class="admin-btn danger" data-action="stopCand" data-cat="${cat}">Arrêter candidature</button>
+      <button class="admin-btn" data-action="startVote" data-cat="${cat}">Démarrer vote</button>
+      <button class="admin-btn danger" data-action="stopVote" data-cat="${cat}">Arrêter vote</button>
+    `;
+    container.appendChild(section);
+  });
+
+  container.addEventListener('click', ev => {
+    const btn = ev.target;
+    const action = btn.dataset.action;
+    const cat = btn.dataset.cat;
+    if (!action || !cat) return;
+    switch (action) {
+      case 'startCand':
+        startCand(cat);
+        break;
+      case 'stopCand':
+        stopCand(cat);
+        break;
+      case 'startVote':
+        startVoteCat(cat);
+        break;
+      case 'stopVote':
+        stopVoteCat(cat);
+        break;
+    }
+  });
+}
+
+function startCand(cat) {
+  const deb = prompt('Date de d\u00e9but (YYYY-MM-DD HH:MM)');
+  const fin = prompt('Date de fin (YYYY-MM-DD HH:MM)');
+  if (!deb || !fin) return;
+  const d = Date.parse(deb);
+  const f = Date.parse(fin);
+  if (isNaN(d) || isNaN(f) || d >= f) { alert('Dates invalides'); return; }
+  if (isCandidatureActive(cat)) { alert('Une session est d\u00e9j\u00e0 ouverte'); return; }
+  startCandidature(cat, d, f);
+  alert('Candidature ouverte pour ' + cat.toUpperCase());
+}
+
+function stopCand(cat) {
+  if (!isCandidatureActive(cat)) { alert('Aucune session active'); return; }
+  endCandidature(cat);
+  alert('Candidature stopp\u00e9e pour ' + cat.toUpperCase());
+}
+
+function startVoteCat(cat) {
+  const deb = prompt('Date de d\u00e9but (YYYY-MM-DD HH:MM)');
+  const fin = prompt('Date de fin (YYYY-MM-DD HH:MM)');
+  if (!deb || !fin) return;
+  const d = Date.parse(deb);
+  const f = Date.parse(fin);
+  if (isNaN(d) || isNaN(f) || d >= f) { alert('Dates invalides'); return; }
+  const state = getState();
+  if (state.vote.active) { alert('Une session de vote est d\u00e9j\u00e0 ouverte'); return; }
+  startVote(cat, d, f);
+  alert('Vote ouvert pour ' + cat.toUpperCase());
+}
+
+function stopVoteCat(cat) {
+  const state = getState();
+  if (!state.vote.active || state.vote.category !== cat) { alert('Pas de vote actif pour cette cat\u00e9gorie'); return; }
+  endVote();
+  alert('Vote stopp\u00e9 pour ' + cat.toUpperCase());
+}

--- a/E-election/pages/moi.html
+++ b/E-election/pages/moi.html
@@ -10,6 +10,7 @@
 <body>
   <div id="header"></div>
   <div class="profile-container" id="profileContainer"></div>
+  <div class="committee-actions" id="committeeActions"></div>
   <div id="footer"></div>
 
   <script src="../assets/js/include.js"></script>
@@ -17,6 +18,7 @@
     includeComponent('#header', '../components/header.html');
     includeComponent('#footer', '../components/footer.html');
   </script>
+  <script src="../assets/js/state.js"></script>
   <script src="../assets/js/moi.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show committee start/stop buttons on `moi.html`
- display extended user info with optional photo and nationality
- allow committee members to manage candidatures and votes
- style profile page buttons

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846f843e1588325a72b869b3f34cd31