### PR TITLE
Fix profile modals and restrict session closure

### DIFF
--- a/E-election/pages/moi.html
+++ b/E-election/pages/moi.html
@@ -80,6 +80,20 @@
       </div>
     </div>
   </div>
+  <!-- Modal pour fermer une session -->
+  <div id="closeSessionModal" class="modal">
+    <div class="modal-content">
+      <span class="close-btn" id="closeCloseSession">&times;</span>
+      <div class="form-group">
+        <label for="closeSessionCategory">Catégorie</label>
+        <select id="closeSessionCategory"></select>
+      </div>
+      <div class="form-actions">
+        <button class="admin-btn danger" id="cancelCloseSession">Annuler</button>
+        <button class="admin-btn" id="validateCloseSession">Valider</button>
+      </div>
+    </div>
+  </div>
   <div id="footer"></div>
 
   <script src="../assets/js/include.js"></script>


### PR DESCRIPTION
## Summary
- expose modal reset functions and call them via `window`
- add modal to close sessions from profile
- limit closing options to committee categories

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684704afbbf88325b7a0bed96fdf914d