### PR TITLE
Fix session management with global state

### DIFF
--- a/E-election/assets/js/admin_accueil.js
+++ b/E-election/assets/js/admin_accueil.js
@@ -57,27 +57,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Gestion des candidatures sessions (stockage et contrôle)
   function isCandidatureActive(categorie) {
-    let candidatures = JSON.parse(localStorage.getItem('candidaturesSessions') || '{}');
-    return candidatures[categorie] && candidatures[categorie].active;
+    return window.isCandidatureActive(categorie);
   }
 
   function startCandidature(categorie, debut, fin, club) {
-    let candidatures = JSON.parse(localStorage.getItem('candidaturesSessions') || '{}');
-    candidatures[categorie] = {
-      active: true,
-      start: debut,
-      end: fin,
-      ...(categorie === 'club' ? { club } : {})
-    };
-    localStorage.setItem('candidaturesSessions', JSON.stringify(candidatures));
+    window.startCandidature(categorie, debut, fin, club);
   }
 
   function endCandidature(categorie) {
-    let candidatures = JSON.parse(localStorage.getItem('candidaturesSessions') || '{}');
-    if (candidatures[categorie]) {
-      candidatures[categorie].active = false;
-      localStorage.setItem('candidaturesSessions', JSON.stringify(candidatures));
-    }
+    window.endCandidature(categorie);
   }
 
   // ===============================
@@ -86,60 +74,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Vérifie si une session de vote est active pour une catégorie
   function isVoteActive(categorie) {
-    let votes = JSON.parse(localStorage.getItem('votesSessions') || '{}');
-    // Fermeture automatique si la date de fin est dépassée
-    if (votes[categorie] && votes[categorie].active && Date.now() > votes[categorie].end) {
-      votes[categorie].active = false;
-      localStorage.setItem('votesSessions', JSON.stringify(votes));
-      return false;
-    }
-    return votes[categorie] && votes[categorie].active;
+    return window.isVoteActive(categorie);
   }
 
   // Démarre une session de vote pour une catégorie
   function startVote(categorie, debut, fin, club) {
-    let votes = JSON.parse(localStorage.getItem('votesSessions') || '{}');
-    votes[categorie] = {
-      active: true,
-      start: debut,
-      end: fin,
-      ...(categorie === 'club' ? { club } : {})
-    };
-    localStorage.setItem('votesSessions', JSON.stringify(votes));
+    window.startVote(categorie, debut, fin, club);
   }
 
   // Ferme une session de vote pour une catégorie
   function endVote(categorie) {
-    let votes = JSON.parse(localStorage.getItem('votesSessions') || '{}');
-    if (votes[categorie] && votes[categorie].active) {
-      votes[categorie].active = false;
-      localStorage.setItem('votesSessions', JSON.stringify(votes));
-    }
+    window.endVote(categorie);
   }
 
   // Fermeture automatique des votes et candidatures à chaque chargement
   function autoCloseSessions() {
-    // Candidatures
-    let candidatures = JSON.parse(localStorage.getItem('candidaturesSessions') || '{}');
-    let changed = false;
-    Object.keys(candidatures).forEach(cat => {
-      if (candidatures[cat].active && Date.now() > candidatures[cat].end) {
-        candidatures[cat].active = false;
-        changed = true;
-      }
-    });
-    if (changed) localStorage.setItem('candidaturesSessions', JSON.stringify(candidatures));
-
-    // Votes
-    let votes = JSON.parse(localStorage.getItem('votesSessions') || '{}');
-    changed = false;
-    Object.keys(votes).forEach(cat => {
-      if (votes[cat].active && Date.now() > votes[cat].end) {
-        votes[cat].active = false;
-        changed = true;
-      }
-    });
-    if (changed) localStorage.setItem('votesSessions', JSON.stringify(votes));
+    getState(); // déclenche la vérification et la fermeture automatique via state.js
   }
   autoCloseSessions();
 

--- a/E-election/assets/js/header.js
+++ b/E-election/assets/js/header.js
@@ -57,9 +57,18 @@ document.addEventListener('DOMContentLoaded', function() {
     toggleLink('a[href$="campagnes.html"]', !candidatureOn);
     toggleLink('a[href$="vote.html"]', !voteOn);
 
-    const canSeeStats = state.vote.category && userHasVoted(state.vote.category);
+    const categories = ['aes', 'classe', 'club'];
+    let canSeeStats = false;
+    let showResults = false;
+    categories.forEach(cat => {
+      const v = cat === 'club' ? state.vote.club : state.vote[cat];
+      if (!v) return;
+      if (v.active && userHasVoted(cat)) canSeeStats = true;
+      if (!v.active && v.endTime && Date.now() >= v.endTime && Date.now() <= v.endTime + 7 * 24 * 60 * 60 * 1000) {
+        showResults = true;
+      }
+    });
     toggleLink('a[href$="statistique.html"]', !canSeeStats);
-    const showResults = state.vote.category && !voteOn && state.vote.endTime && Date.now() >= state.vote.endTime && Date.now() <= state.vote.endTime + 7 * 24 * 60 * 60 * 1000;
     toggleLink('a[href$="resultat.html"]', !showResults);
   }
 

--- a/E-election/assets/js/moi.js
+++ b/E-election/assets/js/moi.js
@@ -101,10 +101,10 @@ function setupModals(categories) {
 
   function fillCloseOptions(type) {
     closeSessionCategory.innerHTML = '<option value="" selected disabled>Choisir une catégorie</option>';
-    const key = type === 'vote' ? 'votesSessions' : 'candidaturesSessions';
-    const sessions = JSON.parse(localStorage.getItem(key) || '{}');
+    const state = getState();
     categories.forEach(c => {
-      if (sessions[c] && sessions[c].active) {
+      const sess = type === 'vote' ? (c === 'club' ? state.vote.club : state.vote[c]) : (c === 'club' ? state.candidature.club : state.candidature[c]);
+      if (sess && sess.active) {
         const opt = document.createElement('option');
         opt.value = c;
         opt.textContent = c.toUpperCase();
@@ -169,7 +169,7 @@ function setupModals(categories) {
       alert('Impossible de démarrer le vote : la session de candidature pour cette catégorie est encore ouverte.');
       return;
     }
-    startVote(categorie, debut, fin);
+    window.startVote(categorie, debut, fin);
     alert('Votes démarrés pour ' + categorie.toUpperCase());
     startVotesModal.style.display = 'none';
     resetVoteModal();
@@ -189,7 +189,7 @@ function setupModals(categories) {
     if (!categorie) { alert('Catégorie manquante'); return; }
     if (isNaN(debut) || isNaN(fin) || debut >= fin) { alert('Dates invalides'); return; }
     if (isCandidatureSessionActive(categorie)) { alert('Cette catégorie possède déjà une session active'); return; }
-    startCandidatureSession(categorie, debut, fin);
+    window.startCandidature(categorie, debut, fin);
     alert('Candidatures ouvertes pour ' + categorie.toUpperCase());
     startCandModal.style.display = 'none';
     resetCandModal();
@@ -202,7 +202,7 @@ function setupModals(categories) {
     if (!cat) { alert('Choisissez une catégorie'); return; }
     if (closeType === 'vote') {
       if (!isVoteActive(cat)) { alert('Pas de session de vote ouverte pour cette catégorie'); return; }
-      endVote(cat);
+      window.endVote(cat);
       alert('Votes fermés pour ' + cat.toUpperCase());
     } else {
       if (!isCandidatureSessionActive(cat)) { alert('Pas de session ouverte pour cette catégorie'); return; }
@@ -214,59 +214,20 @@ function setupModals(categories) {
 }
 
 function isCandidatureSessionActive(categorie) {
-  let candidatures = JSON.parse(localStorage.getItem('candidaturesSessions') || '{}');
-  if (candidatures[categorie] && candidatures[categorie].active && Date.now() > candidatures[categorie].end) {
-    candidatures[categorie].active = false;
-    localStorage.setItem('candidaturesSessions', JSON.stringify(candidatures));
-    // Mise à jour de l'état global
-    const state = getState();
-    if (state.candidature[categorie]) {
-      state.candidature[categorie].active = false;
-      saveState(state);
-    }
-    return false;
-  }
-  return candidatures[categorie] && candidatures[categorie].active;
+  return window.isCandidatureActive(categorie);
 }
 
 function startCandidatureSession(categorie, debut, fin) {
-  let candidatures = JSON.parse(localStorage.getItem('candidaturesSessions') || '{}');
-  candidatures[categorie] = { active: true, start: debut, end: fin };
-  localStorage.setItem('candidaturesSessions', JSON.stringify(candidatures));
-  // Synchronise avec electionState
-  startCandidature(categorie, debut, fin);
+  window.startCandidature(categorie, debut, fin);
 }
 
 function endCandidatureSession(categorie) {
-  let candidatures = JSON.parse(localStorage.getItem('candidaturesSessions') || '{}');
-  if (candidatures[categorie]) {
-    candidatures[categorie].active = false;
-    localStorage.setItem('candidaturesSessions', JSON.stringify(candidatures));
-    endCandidature(categorie);
-  }
+  window.endCandidature(categorie);
 }
 
 function isVoteActive(categorie) {
-  let votes = JSON.parse(localStorage.getItem('votesSessions') || '{}');
-  if (votes[categorie] && votes[categorie].active && Date.now() > votes[categorie].end) {
-    votes[categorie].active = false;
-    localStorage.setItem('votesSessions', JSON.stringify(votes));
-    return false;
-  }
-  return votes[categorie] && votes[categorie].active;
+  return window.isVoteActive(categorie);
 }
 
-function startVote(categorie, debut, fin) {
-  let votes = JSON.parse(localStorage.getItem('votesSessions') || '{}');
-  votes[categorie] = { active: true, start: debut, end: fin };
-  localStorage.setItem('votesSessions', JSON.stringify(votes));
-}
 
-function endVote(categorie) {
-  let votes = JSON.parse(localStorage.getItem('votesSessions') || '{}');
-  if (votes[categorie] && votes[categorie].active) {
-    votes[categorie].active = false;
-    localStorage.setItem('votesSessions', JSON.stringify(votes));
-  }
-}
 

--- a/E-election/assets/js/resultat.js
+++ b/E-election/assets/js/resultat.js
@@ -43,20 +43,19 @@ function getVoteKey(type, index) {
 }
 
 function getVoteSessionStatus(type) {
-    let votes = JSON.parse(localStorage.getItem('votesSessions') || '{}');
-    if (!votes[type]) return { status: 'none', session: null };
-    const session = votes[type];
+    const state = getState();
+    const session = type === 'club' ? state.vote.club : state.vote[type];
+    if (!session) return { status: 'none', session: null };
     const now = Date.now();
 
-    if (session.active && now > session.end) {
+    if (session.active && now > session.endTime) {
         session.active = false;
-        votes[type] = session;
-        localStorage.setItem('votesSessions', JSON.stringify(votes));
+        saveState(state);
     }
 
-    if (now < session.start) return { status: 'not_started', session };
-    if (session.active && now <= session.end) return { status: 'active', session };
-    if (now >= session.end) return { status: 'closed', session };
+    if (now < session.startTime) return { status: 'not_started', session };
+    if (session.active && now <= session.endTime) return { status: 'active', session };
+    if (now >= session.endTime) return { status: 'closed', session };
     return { status: 'none', session };
 }
 

--- a/E-election/assets/js/statistique.js
+++ b/E-election/assets/js/statistique.js
@@ -74,10 +74,7 @@ function totalVotes(type, data) {
 // Vérifie si une session de vote est active et commencée pour une catégorie
 // ===============================
 function isVoteActive(categorie) {
-    let votes = JSON.parse(localStorage.getItem('votesSessions') || '{}');
-    if (!votes[categorie]) return false;
-    const now = Date.now();
-    return votes[categorie].active && now >= votes[categorie].start && now <= votes[categorie].end;
+    return window.isVoteActive(categorie);
 }
 function hasVotedAll(type) {
     if (type === 'aes') {


### PR DESCRIPTION
## Summary
- centralize session state in `state.js`
- update navigation logic to read new state
- sync session management UI with global state
- reference global state from vote and result scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684723c755d88325860692985aebdf1b