### PR TITLE
Fix broken navigation and filters

### DIFF
--- a/E-election/assets/js/header.js
+++ b/E-election/assets/js/header.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function() {
+function initHeader() {
   // Activation onglet courant
   document.querySelectorAll('.nav-link').forEach(link => {
     link.addEventListener('click', function (e) {
@@ -74,4 +74,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
   document.addEventListener('DOMContentLoaded', updateNavVisibility);
   document.addEventListener('stateChanged', updateNavVisibility);
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initHeader);
+} else {
+  initHeader();
+}

--- a/E-election/pages/Acceuil.html
+++ b/E-election/pages/Acceuil.html
@@ -65,7 +65,6 @@
         includeComponent('#header', '../components/header.html');
         includeComponent('#footer', '../components/footer.html');
     </script>
-    <script src="../assets/js/header.js"></script>
 
 </body>
 </html>

--- a/E-election/pages/admin_accueil.html
+++ b/E-election/pages/admin_accueil.html
@@ -108,11 +108,11 @@
   <script src="assets/js/include.js"></script>
   <script>
     includeComponent('#header', '../components/header.html');
-    includeComponent('#footer', '../components/footer.html'); 
+    includeComponent('#footer', '../components/footer.html');
   </script>
+  <script src="../assets/js/state.js"></script>
 
   <script src="../assets/js/admin_accueil.js"></script>
-  <script src="../assets/js/header.js"></script>
   
 </body>
 </html>

--- a/E-election/pages/campagnes.html
+++ b/E-election/pages/campagnes.html
@@ -44,7 +44,6 @@
     </script>
     <!-- JS principal pour la gestion des campagnes -->
     <script src="../assets/js/campagne.js"></script>
-    <script src="../assets/js/header.js"></script>
     
 </body>
 </html>

--- a/E-election/pages/mes-candidatures.html
+++ b/E-election/pages/mes-candidatures.html
@@ -37,7 +37,6 @@
     </script>
 
   <script src="../assets/js/mes-candidatures.js"></script>
-  <script src="../assets/js/header.js"></script>
   
 </body>
 </html>

--- a/E-election/pages/moi.html
+++ b/E-election/pages/moi.html
@@ -101,6 +101,7 @@
     includeComponent('#header', '../components/header.html');
     includeComponent('#footer', '../components/footer.html');
   </script>
+  <script src="../assets/js/state.js"></script>
   <script src="../assets/js/moi.js"></script>
 </body>
 </html>

--- a/E-election/pages/resultat.html
+++ b/E-election/pages/resultat.html
@@ -34,8 +34,8 @@
         includeComponent('#header', '../components/header.html');
         includeComponent('#footer', '../components/footer.html');
     </script>
+    <script src="../assets/js/state.js"></script>
     <script src="../assets/js/resultat.js"></script>
-    <script src="../assets/js/header.js"></script>
 
     
 </body>

--- a/E-election/pages/statistique.html
+++ b/E-election/pages/statistique.html
@@ -44,9 +44,9 @@
         includeComponent('#header', '../components/header.html');
         includeComponent('#footer', '../components/footer.html');
     </script>
+    <script src="../assets/js/state.js"></script>
     <!-- JS du tableau de bord -->
     <script src="../assets/js/statistique.js"></script>
-    <script src="../assets/js/header.js"></script>
     
 </body>
 </html>

--- a/E-election/pages/vote.html
+++ b/E-election/pages/vote.html
@@ -39,9 +39,9 @@
         includeComponent('#header', '../components/header.html');
         includeComponent('#footer', '../components/footer.html');
     </script>
+    <script src="../assets/js/state.js"></script>
     <!-- JS principal pour la gestion des votes -->
     <script src="../assets/js/vote.js"></script>
-    <script src="../assets/js/header.js"></script>
     
 </body>
 </html>


### PR DESCRIPTION
## Summary
- initialize header scripts after dynamic load
- include `state.js` in pages that depend on it
- avoid redundant `header.js` tags

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684727946eec8325b8d56fb9fdcec171