### PR TITLE
Add basic mocha test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,14 @@ Le site sera accessible sur [http://localhost:3000](http://localhost:3000).
 - Des sessions sont sauvegardées dans `backend/data/sessions.json`.
 
 Pour accéder aux endpoints sécurisés (création de candidature, vote...), le jeton doit être envoyé dans l'en-tête `Authorization: Bearer <token>`.
+
+## Tests backend
+
+Une suite de tests automatisés vérifie les principaux endpoints du serveur. Pour les lancer :
+
+```bash
+cd backend
+npm test
+```
+
+Les tests démarrent le serveur en mémoire et s'assurent du bon fonctionnement de l'inscription, de la connexion et de la protection des routes nécessitant une authentification.

--- a/backend/README.md
+++ b/backend/README.md
@@ -34,3 +34,12 @@ Les fichiers JSON contiennent des tableaux d'objets simples :
 - `elections.json` : `{id, name}`
 - `candidates.json` : `{id, electionId, name}`
 - `votes.json` : `{id, userId, electionId, candidateId}`
+
+## Tests
+
+Des tests automatisés valident les principaux endpoints à l'aide de Mocha et Supertest.
+Pour exécuter la suite :
+
+```bash
+npm test
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,10 +4,15 @@
   "description": "Simple Node.js backend for E-Vote ENSAE",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "mocha"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "mocha": "^10.0.0",
+    "supertest": "^6.0.0"
+  }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -91,7 +91,7 @@ function authenticate(req) {
   return null;
 }
 
-const server = http.createServer((req, res) => {
+function requestHandler(req, res) {
   if (req.method === 'GET' && !req.url.startsWith('/api/')) {
     if (serveStatic(req, res)) return;
   }
@@ -192,8 +192,16 @@ const server = http.createServer((req, res) => {
   }
 
   send(res, 404, { error: 'Not found' });
-});
+}
 
-server.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+function createServer() {
+  return http.createServer(requestHandler);
+}
+
+if (require.main === module) {
+  createServer().listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
+
+module.exports = { createServer };

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const request = require('supertest');
+const { createServer } = require('../server');
+
+describe('API endpoints', function () {
+  let server;
+  let agent;
+  const dataDir = path.join(__dirname, '..', 'data');
+
+  before(function (done) {
+    // reset data files
+    fs.writeFileSync(path.join(dataDir, 'users.json'), '[]');
+    fs.writeFileSync(path.join(dataDir, 'sessions.json'), '{}');
+    fs.writeFileSync(path.join(dataDir, 'candidates.json'), '[]');
+
+    server = createServer().listen(0, done);
+  });
+
+  after(function (done) {
+    server.close(done);
+  });
+
+  before(function () {
+    agent = request(server);
+  });
+
+  it('POST /api/register creates a user', async function () {
+    await agent
+      .post('/api/register')
+      .send({ email: 'test@example.com', password: 'secret' })
+      .expect(201);
+  });
+
+  it('POST /api/login returns a token', async function () {
+    const res = await agent
+      .post('/api/login')
+      .send({ email: 'test@example.com', password: 'secret' })
+      .expect(200);
+    if (!res.body.token) throw new Error('Token manquant');
+  });
+
+  it('POST /api/candidates requires authentication', async function () {
+    await agent
+      .post('/api/candidates')
+      .send({ electionId: 1, name: 'John' })
+      .expect(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha and supertest as dev dependencies
- export a `createServer` function to start the server in tests
- create a first test suite checking the main endpoints
- document `npm test` in README files

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847eee2cb148325b3e9fd42d4304e51