### PR TITLE
Fix login success alert interference

### DIFF
--- a/E-election/assets/js/login.js
+++ b/E-election/assets/js/login.js
@@ -260,11 +260,14 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   });
 
-  document.getElementById("loginForm").addEventListener("submit", function(e) {
-    e.preventDefault();
-    alert("Connexion réussie!");
-    loginModal.style.display = "none";
-  });
+  const modalLoginForm = document.getElementById("loginForm");
+  if (loginModal && modalLoginForm) {
+    modalLoginForm.addEventListener("submit", function(e) {
+      e.preventDefault();
+      alert("Connexion réussie!");
+      loginModal.style.display = "none";
+    });
+  }
 
   // Initialiser la page d'accueil au chargement
   showPage("accueil");


### PR DESCRIPTION
## Summary
- avoid triggering login success alert on dedicated login page

## Testing
- `npm test` *(fails: mocha not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68480e3d41408325ba4dfac57cdfd3a6