### PR TITLE
Fix user profile info

### DIFF
--- a/E-election/assets/js/admin_accueil.js
+++ b/E-election/assets/js/admin_accueil.js
@@ -13,6 +13,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const startVoteInput = document.getElementById('startVote');
   const endVoteInput = document.getElementById('endVote');
 
+  let usersCache = [];
+  fetch('/api/users')
+    .then(r => r.ok ? r.json() : [])
+    .then(data => { usersCache = data; });
+
   // Elements du modal de démarrage des candidatures
   const startCandModal = document.getElementById('startCandModal');
   const closeStartCand = document.getElementById('closeStartCand');
@@ -198,7 +203,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function getUsers() {
-    return JSON.parse(localStorage.getItem('utilisateurs') || '[]');
+    return usersCache;
   }
 
   function getComites() {

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Le site sera accessible sur [http://localhost:3000](http://localhost:3000).
 - Le backend gère désormais l'authentification via un jeton renvoyé lors de la connexion.
 - Les pages d'inscription et de connexion communiquent avec l'API et n'utilisent plus `localStorage` pour stocker les utilisateurs.
 - Des sessions sont sauvegardées dans `backend/data/sessions.json`.
+- Un endpoint `GET /api/users` permet de récupérer la liste des inscrits (sans mots de passe) pour l'administration.
 
 Pour accéder aux endpoints sécurisés (création de candidature, vote...), le jeton doit être envoyé dans l'en-tête `Authorization: Bearer <token>`.
 

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -40,6 +40,12 @@ describe('API endpoints', function () {
     if (!res.body.token) throw new Error('Token manquant');
   });
 
+  it('GET /api/users returns registered users', async function () {
+    const res = await agent.get('/api/users').expect(200);
+    if (!Array.isArray(res.body) || res.body.length !== 1) throw new Error('Liste incorrecte');
+    if (res.body[0].email !== 'test@example.com') throw new Error('Utilisateur manquant');
+  });
+
   it('POST /api/candidates requires authentication', async function () {
     await agent
       .post('/api/candidates')


### PR DESCRIPTION
## Summary
- store registration date and role when creating users
- return registration date & role in `/api/me`
- expose new endpoint `/api/users`
- fetch registered users for committee management
- document `/api/users` endpoint
- test new endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68481310324883259e33aeef06a5b26a