### PR TITLE
Add initial election app

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Vous pouvez tester l'application en ligne via ce lien (⚠️ à ajouter une foi
 
 La partie frontend se trouve dans le dossier `E-election`. Le backend a été ajouté à partir d'un projet **Django** prêt à l'emploi situé dans le dossier `backend/`.
 
+Une application `election` gère désormais les modèles de vote et les vues associées. Elle est connectée au projet Django via les URLs `elections/`.
+
 ### Lancer le backend localement
 
 ```bash

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -14,6 +14,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'core',
+    'election',
 ]
 
 MIDDLEWARE = [

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -4,4 +4,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('core.urls')),
+    path('elections/', include('election.urls')),
 ]

--- a/backend/election/admin.py
+++ b/backend/election/admin.py
@@ -1,0 +1,17 @@
+from django.contrib import admin
+from .models import Election, Candidate, Vote
+
+
+class CandidateInline(admin.TabularInline):
+    model = Candidate
+    extra = 1
+
+
+class ElectionAdmin(admin.ModelAdmin):
+    inlines = [CandidateInline]
+    list_display = ('name', 'start_time', 'end_time', 'active')
+
+
+admin.site.register(Election, ElectionAdmin)
+admin.site.register(Candidate)
+admin.site.register(Vote)

--- a/backend/election/apps.py
+++ b/backend/election/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ElectionConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'election'

--- a/backend/election/forms.py
+++ b/backend/election/forms.py
@@ -1,0 +1,17 @@
+from django import forms
+from .models import Vote, Candidate
+
+
+class VoteForm(forms.ModelForm):
+    class Meta:
+        model = Vote
+        fields = ['candidate', 'voter_name']
+        widgets = {
+            'voter_name': forms.TextInput(attrs={'placeholder': 'Your ID'})
+        }
+
+    def __init__(self, *args, **kwargs):
+        election = kwargs.pop('election', None)
+        super().__init__(*args, **kwargs)
+        if election is not None:
+            self.fields['candidate'].queryset = Candidate.objects.filter(election=election)

--- a/backend/election/models.py
+++ b/backend/election/models.py
@@ -1,0 +1,35 @@
+from django.db import models
+
+
+class Election(models.Model):
+    name = models.CharField(max_length=255)
+    start_time = models.DateTimeField()
+    end_time = models.DateTimeField()
+    active = models.BooleanField(default=True)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        ordering = ['-start_time']
+
+
+class Candidate(models.Model):
+    election = models.ForeignKey(Election, on_delete=models.CASCADE, related_name='candidates')
+    name = models.CharField(max_length=255)
+    manifesto = models.TextField(blank=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Vote(models.Model):
+    election = models.ForeignKey(Election, on_delete=models.CASCADE, related_name='votes')
+    candidate = models.ForeignKey(Candidate, on_delete=models.CASCADE, related_name='votes')
+    voter_name = models.CharField(max_length=255)
+
+    class Meta:
+        unique_together = ('election', 'voter_name')
+
+    def __str__(self):
+        return f"{self.voter_name} -> {self.candidate.name}"

--- a/backend/election/urls.py
+++ b/backend/election/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+from . import views
+
+app_name = 'election'
+
+urlpatterns = [
+    path('', views.election_list, name='list'),
+    path('<int:pk>/', views.election_detail, name='detail'),
+    path('<int:pk>/results/', views.election_results, name='results'),
+]

--- a/backend/election/views.py
+++ b/backend/election/views.py
@@ -1,0 +1,36 @@
+from django.shortcuts import get_object_or_404, render, redirect
+from django.db.models import Count
+from .models import Election
+from .forms import VoteForm
+
+
+def election_list(request):
+    elections = Election.objects.all()
+    return render(request, 'election/election_list.html', {'elections': elections})
+
+
+def election_detail(request, pk):
+    election = get_object_or_404(Election, pk=pk)
+    form = VoteForm(request.POST or None, election=election)
+    voted = False
+
+    if request.method == 'POST' and form.is_valid():
+        vote = form.save(commit=False)
+        vote.election = election
+        vote.save()
+        voted = True
+
+    return render(request, 'election/election_detail.html', {
+        'election': election,
+        'form': form,
+        'voted': voted
+    })
+
+
+def election_results(request, pk):
+    election = get_object_or_404(Election, pk=pk)
+    results = election.candidates.annotate(vote_count=Count('votes'))
+    return render(request, 'election/election_results.html', {
+        'election': election,
+        'results': results
+    })

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>E-Vote</title>
+</head>
+<body>
+    <header>
+        <h1><a href="/">E-Vote ENSAE</a></h1>
+        <nav>
+            <a href="/elections/">Elections</a>
+        </nav>
+    </header>
+    <hr>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/election/election_detail.html
+++ b/templates/election/election_detail.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ election.name }}</h2>
+<p>Start: {{ election.start_time }} | End: {{ election.end_time }}</p>
+
+{% if voted %}
+<p>Thank you for voting!</p>
+{% else %}
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Vote</button>
+</form>
+{% endif %}
+
+<a href="{% url 'election:results' election.pk %}">View Results</a>
+{% endblock %}

--- a/templates/election/election_list.html
+++ b/templates/election/election_list.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Elections</h2>
+<ul>
+  {% for election in elections %}
+    <li><a href="{% url 'election:detail' election.pk %}">{{ election.name }}</a></li>
+  {% empty %}
+    <li>No elections available.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/election/election_results.html
+++ b/templates/election/election_results.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Results for {{ election.name }}</h2>
+<ul>
+  {% for candidate in results %}
+    <li>{{ candidate.name }} - {{ candidate.vote_count }} vote{{ candidate.vote_count|pluralize }}</li>
+  {% endfor %}
+</ul>
+<a href="{% url 'election:detail' election.pk %}">Back to election</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `election` Django app with models, forms, views and urls
- register the app in settings and project urls
- add minimal templates for elections
- note the new app in the README

## Testing
- `python -m py_compile backend/election/*.py backend/*.py`
- `python backend/manage.py check` *(fails: `No module named 'django'`)*

------
https://chatgpt.com/codex/tasks/task_e_685787a95e188325b84520e7825874da